### PR TITLE
Fix keypath and overload resolution oddity.

### DIFF
--- a/src/WixToolset.Converters.Tupleizer/ConvertTuples.cs
+++ b/src/WixToolset.Converters.Tupleizer/ConvertTuples.cs
@@ -10,15 +10,15 @@ namespace WixToolset.Converters.Tupleizer
     using WixToolset.Data.WindowsInstaller;
     using Wix3 = Microsoft.Tools.WindowsInstallerXml;
 
-    public class ConvertTuplesCommand
+    public static class ConvertTuples
     {
-        public Intermediate Execute(string path)
+        public static Intermediate ConvertFile(string path)
         {
             var output = Wix3.Output.Load(path, suppressVersionCheck: true, suppressSchema: true);
-            return this.Execute(output);
+            return ConvertOutput(output);
         }
 
-        public Intermediate Execute(Wix3.Output output)
+        public static Intermediate ConvertOutput(Wix3.Output output)
         {
             var section = new IntermediateSection(String.Empty, OutputType3ToSectionType4(output.Type), output.Codepage);
 
@@ -118,7 +118,8 @@ namespace WixToolset.Converters.Tupleizer
                     location = ComponentLocation.Either;
                 }
 
-                var keyPathType = ComponentKeyPathType.File;
+                var keyPath = FieldAsString(row, 5);
+                var keyPathType = String.IsNullOrEmpty(keyPath) ? ComponentKeyPathType.Directory : ComponentKeyPathType.File;
                 if ((attributes & WindowsInstallerConstants.MsidbComponentAttributesRegistryKeyPath) == WindowsInstallerConstants.MsidbComponentAttributesRegistryKeyPath)
                 {
                     keyPathType = ComponentKeyPathType.Registry;
@@ -133,7 +134,7 @@ namespace WixToolset.Converters.Tupleizer
                     ComponentId = FieldAsString(row, 1),
                     DirectoryRef = FieldAsString(row, 2),
                     Condition = FieldAsString(row, 4),
-                    KeyPath = FieldAsString(row, 5),
+                    KeyPath = keyPath,
                     Location = location,
                     DisableRegistryReflection = (attributes & WindowsInstallerConstants.MsidbComponentAttributesDisableRegistryReflection) == WindowsInstallerConstants.MsidbComponentAttributesDisableRegistryReflection,
                     NeverOverwrite = (attributes & WindowsInstallerConstants.MsidbComponentAttributesNeverOverwrite) == WindowsInstallerConstants.MsidbComponentAttributesNeverOverwrite,

--- a/src/test/WixToolsetTest.Converters.Tupleizer/ConvertTuplesFixture.cs
+++ b/src/test/WixToolsetTest.Converters.Tupleizer/ConvertTuplesFixture.cs
@@ -27,10 +27,8 @@ namespace WixToolsetTest.Converters.Tupleizer
                 var intermediateFolder = fs.GetFolder();
 
                 var path = Path.Combine(dataFolder, "test.wixout");
-                var output = Wix3.Output.Load(path, suppressVersionCheck: true, suppressSchema: true);
 
-                var command = new ConvertTuplesCommand();
-                var intermediate = command.Execute(output);
+                var intermediate = ConvertTuples.ConvertFile(path);
 
                 Assert.NotNull(intermediate);
                 Assert.Single(intermediate.Sections);
@@ -43,6 +41,7 @@ namespace WixToolsetTest.Converters.Tupleizer
 
                 intermediate = Intermediate.Load(wixiplFile);
 
+                var output = Wix3.Output.Load(path, suppressVersionCheck: true, suppressSchema: true);
                 var wixMediaByDiskId = IndexWixMediaTableByDiskId(output);
 
                 // Dump to text for easy diffing, with some massaging to keep v3 and v4 diffable.


### PR DESCRIPTION
- Ensure a component with directory keypath is accurately reflected in
`ComponentTuple.KeyPathType`.
- To ensure callers don't have to reference wix.dll, have a single
`Execute` method.